### PR TITLE
$config['gateways'] not array throws warning

### DIFF
--- a/src/usr/local/www/status_gateway_groups.php
+++ b/src/usr/local/www/status_gateway_groups.php
@@ -35,7 +35,8 @@ define('COLOR', true);
 
 require_once("guiconfig.inc");
 
-if (!is_array($config['gateways']['gateway_group'])) {
+if (!is_array($config['gateways']['gateway_group'] || !is_array($config)['gateways'])) {
+	$config['gateways'] = array('gateway_group');
 	$config['gateways']['gateway_group'] = array();
 }
 


### PR DESCRIPTION
so initialize it first

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review